### PR TITLE
Fix for posting video stories

### DIFF
--- a/pysnap/__init__.py
+++ b/pysnap/__init__.py
@@ -375,7 +375,7 @@ class Snapchat(object):
             })
         return len(r.content) == 0
 
-    def send_to_story(self, media_id, time=5, media_type = 0):
+    def send_to_story(self, media_id, time=5, media_type=0):
         """Send a snap to your story. Requires a media_id returned by the upload method
            Returns true if the snap was sent successfully.
         """

--- a/pysnap/__init__.py
+++ b/pysnap/__init__.py
@@ -375,7 +375,7 @@ class Snapchat(object):
             })
         return len(r.content) == 0
 
-    def send_to_story(self, media_id, time=5):
+    def send_to_story(self, media_id, time=5, media_type = 0):
         """Send a snap to your story. Requires a media_id returned by the upload method
            Returns true if the snap was sent successfully.
         """
@@ -384,7 +384,7 @@ class Snapchat(object):
             'media_id': media_id,
             'client_id': media_id,
             'time': time,
-            'type': 0,
+            'type': media_type,
             'zipped': '0'
             })
         return r.json()


### PR DESCRIPTION
Currently you're setting media_type to 0 which makes it impossible to use the method to add a video to your story. The pull request makes media_type an optional argument. 