### PR TITLE
Raise exception if login is unsuccessful

### DIFF
--- a/pysnap/__init__.py
+++ b/pysnap/__init__.py
@@ -107,7 +107,7 @@ class Snapchat(object):
 
         if self.username is None and self.auth_token is None:
             raise Exception(result['status'], result['message'])
-            
+
         return result
 
     def logout(self):

--- a/pysnap/__init__.py
+++ b/pysnap/__init__.py
@@ -104,6 +104,10 @@ class Snapchat(object):
             self.auth_token = result['auth_token']
         if 'username' in result:
             self.username = username
+
+        if self.username is None and self.auth_token is None:
+            raise Exception(result['status'], result['message'])
+            
         return result
 
     def logout(self):

--- a/tests/pysnap_tests.py
+++ b/tests/pysnap_tests.py
@@ -45,9 +45,11 @@ class SnapchatTestCase(unittest.TestCase):
     @responses.activate
     def test_login(self):
         responses.add(responses.POST, URL + 'login',
-                      body='{}', status=200,
+                      body='{"auth_token":"123","username":"eggs"}',
+                      status=200,
                       content_type='application/json')
-        self.assertEqual({}, self.snapchat.login('eggs', 'spam'))
+        self.assertEqual({"auth_token": "123", "username": "eggs"},
+                         self.snapchat.login('eggs', 'spam'))
 
         responses.reset()
         responses.add(responses.POST, URL + 'login',
@@ -60,6 +62,13 @@ class SnapchatTestCase(unittest.TestCase):
                       body='', status=200,
                       content_type='application/json')
         self.assertRaises(ValueError, self.snapchat.login, 'eggs', 'spam')
+
+        responses.reset()
+        responses.add(responses.POST, URL + 'login',
+                      body='{"status":"401","message":"Incorrect password"}',
+                      status=200,
+                      content_type='application/json')
+        self.assertRaises(Exception, self.snapchat.login, 'eggs', 'spam')
 
     @responses.activate
     def test_logout(self):


### PR DESCRIPTION
Make a login failure explicit for better handling by clients.